### PR TITLE
Fix hover overlay sizing for task cards

### DIFF
--- a/tests/test_node_serialization.py
+++ b/tests/test_node_serialization.py
@@ -100,7 +100,7 @@ for name in [
     'QLineEdit','QCalendarWidget','QToolButton','QSpinBox','QListWidget',
     'QTabWidget','QGraphicsRectItem','QMessageBox','QInputDialog','QListWidgetItem',
     'QScrollArea','QTreeWidget','QTreeWidgetItem','QFileDialog','QStyleFactory',
-    'QListView','QLayout','QSplitter']:
+    'QListView','QLayout','QSplitter', 'QGraphicsPathItem']:
     setattr(qtwidgets, name, type(name, (), {}))
 
 sys.modules["PyQt5.QtWidgets"] = qtwidgets

--- a/ui/task_files/task_card_lite.py
+++ b/ui/task_files/task_card_lite.py
@@ -135,6 +135,9 @@ class TaskCardLite(QWidget):
         self.hoverOverlay = QWidget(self.parentWidget())
         self.hoverOverlay.setObjectName("card_container")
         self.hoverOverlay.setStyleSheet(self.styleSheet())
+        # Ensure overlay matches the card width and expected height
+        self.hoverOverlay.setFixedWidth(self.width())
+        self.hoverOverlay.setFixedHeight(self.expanded_height)
         # Allow hover events to pass through the overlay so the card still
         # receives them even when covered
         self.hoverOverlay.setAttribute(Qt.WA_TransparentForMouseEvents, True)


### PR DESCRIPTION
## Summary
- keep overlay same width and height for TaskCardLite
- extend test stubs for QGraphicsPathItem

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fd37b8ccc832eac3e87e13c4ca1c6