### PR TITLE
Optimize task loading for dashboard grids

### DIFF
--- a/ui/dashboard_child_view/grid_layout.py
+++ b/ui/dashboard_child_view/grid_layout.py
@@ -49,7 +49,7 @@ class GridLayout(QWidget):
     taskDeleted = pyqtSignal(str)
 
 
-    def __init__(self, logger, grid_title="", filter=None):
+    def __init__(self, logger, grid_title="", filter=None, tasks=None):
         super().__init__()
 
         self.logger = logger
@@ -61,7 +61,11 @@ class GridLayout(QWidget):
         self.num_columns = 1
         self.setAcceptDrops(True)
         self.currentlyDraggedCard = None
-        self.load_known_tasks()
+        # Load tasks if not provided
+        if tasks is not None:
+            self.load_known_tasks(tasks)
+        else:
+            self.load_known_tasks()
         self.initComplete = False
         self.initUI()
         
@@ -73,8 +77,12 @@ class GridLayout(QWidget):
             # Make all cards visible by default if no filter
             self.visibleCards = self.taskCards.copy()
 
-    def load_known_tasks(self):
-        self.tasks = load_tasks_from_json(self.logger)
+    def load_known_tasks(self, tasks=None):
+        """Load tasks either from the provided dictionary or from JSON."""
+        if tasks is not None:
+            self.tasks = tasks
+        else:
+            self.tasks = load_tasks_from_json(self.logger)
 
     def initUI(self):
         self.initCentralWidget()

--- a/ui/dashboard_screen.py
+++ b/ui/dashboard_screen.py
@@ -121,12 +121,14 @@ class DashboardScreen(QWidget):
 
         # If no grid layouts, create at least one grid
         if not self.saved_grid_layouts:
-            grid_layout = GridLayout(logger=self.logger)
+            grid_layout = GridLayout(logger=self.logger, tasks=self.tasks)
             self.task_layout_container.addWidget(grid_layout)
         
         self.main_layout.addWidget(tasks_scroll_area)
 
     def iterrateGridLayouts(self):
+        # Reload tasks and build category dictionary
+        self.tasks = load_tasks_from_json(self.logger)
         # filtered_tasks = {}
         # for idx, grid in enumerate(self.saved_grid_layouts):
         #     filtered_tasks[grid.filter.category if hasattr(grid.filter, 'category') and grid.filter.category else []] = []
@@ -279,7 +281,7 @@ class DashboardScreen(QWidget):
 
 
             # Create grid layout with correct filter
-            grid_layout = GridLayout(logger=self.logger, grid_title=grid.filter.category[0], filter=filter_dict)
+            grid_layout = GridLayout(logger=self.logger, grid_title=grid.filter.category[0], filter=filter_dict, tasks=self.tasks)
             
             # --- Fix Resizing Issues ---
             if idx == 0:  # First grid (top one) should never resize


### PR DESCRIPTION
## Summary
- allow optionally passing tasks into `GridLayout`
- load tasks once in `DashboardScreen.iterrateGridLayouts`
- pass the loaded tasks when creating `GridLayout` instances

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684214cb7adc832eaee17ff80cb08f3e